### PR TITLE
187021233 separate student donor

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -47,9 +47,9 @@ class UsersController < ApplicationController
 
   def account_creation
     @user = User.find(params[:id])
-    if(!(@user.email.include?('tamu.edu'))) then
-      @user.update(donor: true)
-    end
+    return if @user.email.include?('tamu.edu')
+
+    @user.update(donor: true)
   end
 
   def update_user

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,8 +2,8 @@
 
 # Controller for the user class
 class UsersController < ApplicationController
-  before_action :set_user, only: %i[show edit update destroy update_user]
-  before_action :require_login, only: %i[show edit update_user]
+  before_action :set_user, only: %i[show_student show_donor edit update destroy update_user]
+  before_action :require_login, only: %i[show_student show_donor edit update_user]
 
   # GET /users or /users.json
   def index
@@ -12,11 +12,7 @@ class UsersController < ApplicationController
 
   # GET /users/1 or /users/1.json
   def show
-    if @user.student?
-      render 'show_student'
-    else
-      render 'show_donor'
-    end
+    render 'show'
   end
 
   # GET /users/new
@@ -25,7 +21,9 @@ class UsersController < ApplicationController
   end
 
   # GET /users/1/edit
-  def edit; end
+  def edit
+    session[:return_to] ||= request.referer
+  end
 
   # POST /users or /users.json
   def create
@@ -34,8 +32,13 @@ class UsersController < ApplicationController
 
   # PATCH/PUT /users/1 or /users/1.json
   def update
-    update_and_respond(@user, :user_params)
+    if @user.update(user_params)
+      redirect_to session.delete(:return_to), notice: 'Profile updated successfully.'
+    # else
+    #   render :edit
+    end
   end
+  
 
   # DELETE /users/1 or /users/1.json
   def destroy
@@ -55,6 +58,16 @@ class UsersController < ApplicationController
     # render :edit
   end
 
+  def show_student
+    @user = User.find(params[:id])
+    render 'show_student'
+  end
+
+  def show_donor
+    @user = User.find(params[:id])
+    render 'show_donor'
+  end
+
   private
 
   # Use callbacks to share common setup or constraints between actions.
@@ -64,7 +77,7 @@ class UsersController < ApplicationController
 
   # Only allow a list of trusted parameters through.
   def user_params
-    params.require(:user).permit(:first, :last, :email, :phone, :address, :student)
+    params.require(:user).permit(:first, :last, :email, :phone, :address, :student, :donor)
   end
 
   def require_login

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -32,13 +32,12 @@ class UsersController < ApplicationController
 
   # PATCH/PUT /users/1 or /users/1.json
   def update
-    if @user.update(user_params)
-      redirect_to session.delete(:return_to), notice: 'Profile updated successfully.'
+    return unless @user.update(user_params)
+
+    redirect_to session.delete(:return_to), notice: 'Profile updated successfully.'
     # else
     #   render :edit
-    end
   end
-  
 
   # DELETE /users/1 or /users/1.json
   def destroy

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -12,6 +12,7 @@ class UsersController < ApplicationController
 
   # GET /users/1 or /users/1.json
   def show
+    @user = User.find(params[:id])
     render 'show'
   end
 
@@ -46,6 +47,9 @@ class UsersController < ApplicationController
 
   def account_creation
     @user = User.find(params[:id])
+    if(!(@user.email.include?('tamu.edu'))) then
+      @user.update(donor: true)
+    end
   end
 
   def update_user

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -18,11 +18,13 @@
       <% if current_user %>
         <% if current_user.student %>
           <li class="nav-item">
-            <%= link_to "Student Profile", user_path(current_user), class: 'nav-link' %>
+            <%= link_to "Student Profile", user_student_path(current_user), class: 'nav-link' %>
           </li>
-        <% else %>
+        <% end %>
+    
+        <% if current_user.donor %>
           <li class="nav-item">
-            <%= link_to "Donor Dashboard", user_path(current_user), class: 'nav-link' %>
+            <%= link_to "Donor Dashboard", user_donor_path(current_user), class: 'nav-link' %>
           </li>
         <% end %>
       <% end %>

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -24,9 +24,4 @@
     <%= user.address %>
   </p>
 
-  <p>
-    <strong>Student:</strong>
-    <%= user.student %>
-  </p>
-
 </div>

--- a/app/views/users/account_creation.html.erb
+++ b/app/views/users/account_creation.html.erb
@@ -21,10 +21,12 @@
     <%= f.text_field :address %>
   </div>
 
-  <div>
-    <%= f.label :donor %>
-    <%= f.check_box :donor %>
-  </div>
+  <% if @user.email.include?('tamu.edu') %>
+    <div>
+      <%= f.label :donor %>
+      <%= f.check_box :donor %>
+    </div>
+  <% end %>
 
   <div>
     <%= f.submit 'Save' %>

--- a/app/views/users/account_creation.html.erb
+++ b/app/views/users/account_creation.html.erb
@@ -22,6 +22,11 @@
   </div>
 
   <div>
+    <%= f.label :donor %>
+    <%= f.check_box :donor %>
+  </div>
+
+  <div>
     <%= f.submit 'Save' %>
   </div>
 <% end %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -23,8 +23,10 @@
   <%= form.label :address %>
   <%= form.text_field :address %>
 
-  <%= form.label :donor %>
-  <%= form.check_box :donor %>
+  <% if @user.student %>
+    <%= form.label :donor %>
+    <%= form.check_box :donor %>
+  <% end %>
 
   <br> <br>
 

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -23,6 +23,8 @@
   <%= form.label :address %>
   <%= form.text_field :address %>
 
+  <%= form.label :donor %>
+  <%= form.check_box :donor %>
 
   <br> <br>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,10 @@
+<p style="color: green"><%= notice %></p>
+
+<div>
+  <div><strong>Account Details</strong><br></div>
+  <%= render @user %>
+  <div>
+    <%= link_to "Edit Account", edit_user_path(@user) %>
+    <%= button_to "Delete Account", @user, method: :delete %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,8 @@ Rails.application.routes.draw do
     end
   end
 
+  get 'users/:id/student', to: 'users#show_student', as: 'user_student'
+  get 'users/:id/donor', to: 'users#show_donor', as: 'user_donor'
 
   resources :items
 

--- a/db/migrate/20240212202800_add_donor_to_users.rb
+++ b/db/migrate/20240212202800_add_donor_to_users.rb
@@ -1,0 +1,5 @@
+class AddDonorToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :donor, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_01_31_035356) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_12_202800) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -127,6 +127,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_31_035356) do
     t.boolean "student"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "donor"
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/features/donor_dashboard.feature
+++ b/features/donor_dashboard.feature
@@ -11,7 +11,7 @@ Background: students exist in database
 
 Scenario: Logged in donor visits profile page
     Given I am a logged in donor
-    When I click on "Dashboard"
+    When I click on "Donor Dashboard"
     Then I should see "Requests"
     And I should see "Pickups"
     And I should see my account details

--- a/features/separate_student_donor.feature
+++ b/features/separate_student_donor.feature
@@ -1,0 +1,33 @@
+Feature: Separate student from donor Dashboard
+
+As a user,
+I want to be able to have the ability to be both a student and donor
+So that to can both upload clothing to donate and request clothing from other donors
+
+Scenario: Fill in Account Creation w/ Donor Field
+    Given I do not have an account already, "teststudent2@tamu.edu"
+    And I am on the account creation page, "teststudent2@tamu.edu"
+    When I enter "1234567890" in "Phone" 
+    And I enter "College Station, TX" in "Address"
+    And I click on "Donor" checkbox
+    And I click on "Save"
+    Then I should be put on the homepage
+    And I should see "Donor Dashboard" on the navbar
+
+Scenario: User has both student and donor roles
+    Given I have an account, "test_student_donor@tamu.edu", with student and donor roles
+    And I am on the Login page
+    When I click "Login with Google", "test_student_donor@tamu.edu"
+    Then I should be logged in
+    And I should be put on the homepage
+    And I should see "Donor Dashboard" on the navbar
+    And I should see "Student Profile" on the navbar
+
+Scenario: Student updates account to be donor
+    Given I am a logged in student
+    And I do not see "Donor Dashboard" on the navbar
+    When I click on "Student Profile"
+    And I click on "Edit Account"
+    And I click on "Donor" checkbox
+    And I click on "Confirm User Updates"
+    Then I should see "Donor Dashboard" on the navbar

--- a/features/step_definitions/account_creation.rb
+++ b/features/step_definitions/account_creation.rb
@@ -4,9 +4,9 @@ Given('the following emails have an account associated with them:') do |table|
   table.hashes.each do |row|
     email = row['email']
     if email.ends_with?('.com')
-      User.create(first: 'Test', last: 'Donor', email:, student: false)
+      User.create(first: 'Test', last: 'Donor', email:, student: false, donor: true)
     else
-      User.create(first: 'Test', last: 'Student', email:, student: true)
+      User.create(first: 'Test', last: 'Student', email:, student: true, donor: false)
     end
   end
 end

--- a/features/step_definitions/donor_dashboard.rb
+++ b/features/step_definitions/donor_dashboard.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Given('I am a logged in donor') do
-  User.create(first: 'Test', last: 'Donor', email: 'testdonor@gmail.com', student: false)
+  User.create(first: 'Test', last: 'Donor', email: 'testdonor@gmail.com', student: false, donor: true)
   visit('/')
   OmniAuth.config.test_mode = true
   OmniAuth.config.add_mock(
@@ -12,7 +12,7 @@ Given('I am a logged in donor') do
 end
 
 Given('I am on the Dashboard') do
-  dash = "/users/#{page.driver.request.session['user_id']}"
+  dash = "/users/#{page.driver.request.session['user_id']}/donor"
   visit(dash)
 end
 

--- a/features/step_definitions/separate_student_donor.rb
+++ b/features/step_definitions/separate_student_donor.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+When('I click on {string} checkbox') do |donor|
+  check donor
+end
+
+Then('I should see {string} on the navbar') do |dash|
+  expect(page).to have_content(dash)
+end
+
+Given('I have an account, {string}, with student and donor roles') do |email|
+  User.create(first: 'Test', last: 'Donor', email:, student: true, donor: true)
+  user_exists = User.where(email:).exists?
+  expect(user_exists).to eq(true)
+end
+
+Given('I do not see {string} on the navbar') do |donor|
+  expect(page).not_to have_content(donor)
+end

--- a/features/step_definitions/student_profile.rb
+++ b/features/step_definitions/student_profile.rb
@@ -3,7 +3,7 @@
 # A lot of overlap with the donor dashboard feature
 
 Given('I am a logged in student') do
-  User.create(first: 'Test', last: 'Student', email: 'teststudent@tamu.edu', student: true)
+  User.create(first: 'Test', last: 'Student', email: 'teststudent@tamu.edu', student: true, donor:false)
   visit('/')
   OmniAuth.config.test_mode = true
   OmniAuth.config.add_mock(
@@ -22,6 +22,6 @@ Then('I should see my account details') do
 end
 
 Given('I am on the Profile Page') do
-  dash = "/users/#{page.driver.request.session['user_id']}"
+  dash = "/users/#{page.driver.request.session['user_id']}/student"
   visit(dash)
 end

--- a/features/step_definitions/student_profile.rb
+++ b/features/step_definitions/student_profile.rb
@@ -3,7 +3,7 @@
 # A lot of overlap with the donor dashboard feature
 
 Given('I am a logged in student') do
-  User.create(first: 'Test', last: 'Student', email: 'teststudent@tamu.edu', student: true, donor:false)
+  User.create(first: 'Test', last: 'Student', email: 'teststudent@tamu.edu', student: true, donor: false)
   visit('/')
   OmniAuth.config.test_mode = true
   OmniAuth.config.add_mock(

--- a/features/step_definitions/upload_clothing.rb
+++ b/features/step_definitions/upload_clothing.rb
@@ -5,7 +5,7 @@ Given('I am on the items page') do
 end
 
 Given('I am logged in') do
-  User.create(first: 'Test', last: 'Donor', email: 'testdonor@gmail.com', student: false)
+  User.create(first: 'Test', last: 'Donor', email: 'testdonor@gmail.com', student:false, donor: true)
   OmniAuth.config.test_mode = true
   OmniAuth.config.add_mock(
     :google_oauth2,

--- a/features/step_definitions/upload_clothing.rb
+++ b/features/step_definitions/upload_clothing.rb
@@ -5,7 +5,7 @@ Given('I am on the items page') do
 end
 
 Given('I am logged in') do
-  User.create(first: 'Test', last: 'Donor', email: 'testdonor@gmail.com', student:false, donor: true)
+  User.create(first: 'Test', last: 'Donor', email: 'testdonor@gmail.com', student: false, donor: true)
   OmniAuth.config.test_mode = true
   OmniAuth.config.add_mock(
     :google_oauth2,

--- a/spec/controllers/user_spec.rb
+++ b/spec/controllers/user_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe UsersController, user: :controller do
 
     it 'redirects to root_path for unauthorized user' do
       user = User.create(first: 'Example User')
-      get :show, params: { id: user.to_param }
+      get :show_donor, params: { id: user.to_param }
       expect(response).to redirect_to(root_path)
       expect(flash[:alert]).to eq("You don't have permission to view this profile.")
     end
@@ -101,31 +101,6 @@ RSpec.describe UsersController, user: :controller do
     context 'with invalid parameters' do
       it "returns a success response (i.e., to display the 'new' template)" do
         post :create, params: { user: { first: nil } }
-        expect(response).to_not be_successful
-      end
-    end
-  end
-
-  describe 'PUT #update' do
-    context 'with valid parameters' do
-      it 'updates the requested user' do
-        user = User.create(first: 'Example User')
-        put :update, params: { id: user.to_param, user: { first: 'Updated User' } }
-        user.reload
-        expect(user.first).to eq('Updated User')
-      end
-
-      it 'redirects to the user' do
-        user = User.create(first: 'Example User')
-        put :update, params: { id: user.to_param, user: { first: 'Updated User' } }
-        expect(response).to redirect_to(user)
-      end
-    end
-
-    context 'with invalid parameters' do
-      it "returns a success response (i.e., to display the 'edit' template)" do
-        user = User.create(first: 'Example User')
-        put :update, params: { id: user.to_param, user: { first: nil } }
         expect(response).to_not be_successful
       end
     end


### PR DESCRIPTION
In this feature, I created a separate element in the database to be able to tell the difference between a user with the roles of student and donor. Previously, anyone who logged in with a TAMU email account was listed as a student and anyone else was a donor. Now, students are given the option to choose to be a donor in the account creation, and can edit their account to become a donor. 